### PR TITLE
Update Test-SecureLDAP

### DIFF
--- a/ActiveDirectory-ps4all/Private/Test-Ldaps.ps1
+++ b/ActiveDirectory-ps4all/Private/Test-Ldaps.ps1
@@ -1,0 +1,25 @@
+Function Test-Ldaps {
+    [cmdletbinding()]
+    param (
+        [parameter(Mandatory)]
+        [string]
+        $DC
+    )
+    process {
+        try {
+            $LDAPS = [ADSI]"LDAP://$($DC):636"
+            $Connection = [ADSI]$LDAPS
+        }
+        catch {
+            Write-Error -ErrorRecord $_
+        }
+        if ($Connection.Path) {
+            Write-Verbose "LDAPS is properly configured on $DC"
+            $true
+        }
+        else {
+            Write-Warning -Message "Cannot establish LDAPS connection to $DC"
+            $false
+        }
+    }
+}

--- a/ActiveDirectory-ps4all/Public/Test-SecureLDAP.ps1
+++ b/ActiveDirectory-ps4all/Public/Test-SecureLDAP.ps1
@@ -1,50 +1,30 @@
-Function Test-SecureLDAP {
+Function Test-SecureLdap {
     [CmdletBinding(DefaultParameterSetName="All")]
     param (
         # Parameter to check LDAPS against all Domain Controllers.
-        [Parameter(Mandatory=$false,
-        ParameterSetName="All")]
+        [Parameter(ParameterSetName="All")]
         [switch]
         $All,
+
         # Name of the Domain Controller.
-        [Parameter(Mandatory=$false,
-        ParameterSetName="DomainController",
-        Position=1)]
+        [Parameter(ParameterSetName="DomainController")]
         [ValidateNotNullOrEmpty()]
         [string]
         $DomainController
     )
     process {
-        Function Test-LDAPS {
-            param (
-                [parameter(Mandatory=$true)]
-                [string]
-                $DC
-            )
-            process {
-                $LDAPS = [ADSI]"LDAP://$($DC):636"
-                try {
-                    $LDAPS = [ADSI]"LDAP://$($DC):636"
-                    $Connection = [adsi]$LDAPS
-                }
-                catch {
-                }
-                if ($Connection.Path) {
-                    Write-Host "LDAPS is properly configured on $DC" -ForegroundColor Green
-                }
-                else {
-                    Write-Error -Message "Cannot establish LDAPS connection to $DC" -ErrorAction Stop
-                }
-            }
-        }
         if ($psCmdlet.ParameterSetName -eq "All") {
-            [array]$DomainControllers = (Get-ADDomainController -Filter *).Name
-            foreach ($DC in $DomainControllers) {
-                Test-LDAPS -DC $DC
+            $DomainControllers = (Get-ADDomainController -Filter *).Name
+            $Output = foreach ($DC in $DomainControllers) {
+                [PsCustomObject]@{
+                    DomainController = $DC
+                    SecureLDAP = Test-Ldaps -DC $DC
+                }
             }
+            $Output
         }
         elseif ($psCmdlet.ParameterSetName -eq "DomainController") {
-            Test-LDAPS -DC $DomainController
+            Test-Ldaps -DC $DomainController
         }
     }
 }


### PR DESCRIPTION
Split out the nested function into it's own file so it's more reusable and fix the output. A Test function should only ever output a Boolean or in the case where multiple booleans might be output (such as this) then it should be structured object that contains booleans as one of the properties. 

Specifying a parameter attribute as $False is unnecessary and that attribute can be removed. Position is also unneeded on different parameter sets and should be avoided in general as PowerShell will figure it out for you, use of positional parameters within a script are generally frowned upon as it can reduce readability for people new to the language or unfamiliar with that particular function. 

Naming of functions and variables should roughly follow .Net standards, which for the most part means PascalCase for public facing things and camelCase for private variables. Acronyms should be capitalised unless there are 3 or more characters in which case it should be mixed case, e.g. `VM` is correct but `Vm` is not, for longer ones `Ldap` is correct but `LDAP` is not. This improves readability when many nouns are put together for a function name as it makes it easier to tell where one word/acronym ends and another starts.